### PR TITLE
Added follow-system theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  
+
   <title>MightySpaceman</title>
   <meta name="description" content="The Official MightySpaceman Website">
   <meta name="author" content="MightySpaceman">
@@ -13,8 +13,8 @@
   <meta property="og:description" content="The Official MightySpaceman Website, showcasing all of my many projects.">
   <meta property="og:image" content="logo.png">
   <meta name="keywords" content="MightySpaceman, mightyspaceman, space, rockets">
-  
-<link id="sheet" rel="stylesheet" href="dark.css">
+
+<link id="themeLink" rel="stylesheet" href="dark.css">
 <link rel="icon" type="image/x-icon" href="Images/logo.png">
 <link href='https://fonts.googleapis.com/css?family=Silkscreen' rel='stylesheet'>
 
@@ -55,7 +55,14 @@
 <hr>
 
 <div class="footer">
-  <p>Dark theme: <input type="checkbox" id="theme"></p>
+  <p>
+    Theme:
+    <select id="themeSelect">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </p>
   <p>
     Contact: <a href="mailto:spaceman384@outlook.com">spaceman384@outlook.com</a>
   </p>

--- a/theme.js
+++ b/theme.js
@@ -1,39 +1,47 @@
-function getCookie(cookieName) {
-  let cookie = {};
-  document.cookie.split(';').forEach(function(el) {
-    let [key,value] = el.split('=');
-    cookie[key.trim()] = value;
-  })
-  
-  return cookie[cookieName];
-};
+const themeLink = document.getElementById("themeLink");
+const themeSelect = document.getElementById("themeSelect");
 
-const theme = document.getElementsByTagName('link')[0];
-const checkbox = document.getElementById('theme');
-
-if (document.cookie.indexOf('theme') == -1) {
-    document.getElementById("theme").checked = true;
-    alert("This website uses cookies to allow you to save your theme.");
-    document.cookie = "theme=dark;";
-    theme.setAttribute('href', 'dark.css');
-
-} else if (getCookie('theme') == 'light') {
-    theme.setAttribute('href', 'light.css');
-
-} else {
-    theme.setAttribute('href', 'dark.css');
+function setTheme(mode) {
+    if (mode === "system") {
+        if (
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: light)").matches
+        ) {
+            mode = "light";
+        } else {
+            mode = "dark";
+        }
+    }
+    if (mode === "light") {
+        themeLink.setAttribute("href", "light.css");
+    } else {
+        themeLink.setAttribute("href", "dark.css");
+    }
 }
 
-checkbox.addEventListener('change', (event) => {
-  if (event.currentTarget.checked) {
+function updateTheme(scheme = null) {
+    if (!scheme) {
+        var scheme = localStorage.getItem("colorScheme");
+        if (scheme === null) {
+            localStorage.setItem("colorScheme", "system");
+            scheme = "system";
+        }
+    }
+    setTheme(scheme);
+    themeSelect.value = scheme;
+}
 
-    theme.setAttribute('href', 'dark.css');
-    document.cookie = "theme=dark;";
-
-  } else {
-
-    theme.setAttribute('href', 'light.css');
-    document.cookie = "theme=light;";
-
-  }
+themeSelect.addEventListener("change", (event) => {
+    if (themeSelect.value) {
+        localStorage.setItem("colorScheme", themeSelect.value);
+        updateTheme();
+    }
 });
+
+window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", (event) => {
+        updateTheme();
+    });
+
+updateTheme();


### PR DESCRIPTION
User-facing changes:
The website now reflects the users OS theme by default.
The theme selection option now allows users to follow-system, or light or dark.

The code was cleaned up and now uses the localstorage API. Because it no longer sends data to the server the cookie notice has been removed - therefore decreasing user friction.