### PR TITLE
Fix broken dark/light theme for secondary pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # MightySpaceman Website Repository
 This is the repository for [https://mightyspaceman.com/](https://mightyspaceman.com/), which I use to update to netlify. The code is here if you want to see it, and feel free to check out the site as well.
 
+Ensure all pages have a `<div class='footer'>` for the dark theme option to be generated.
+
 ## V6 Changelog
 - Added light theme button
 - Added Matrix contact link
-- Cleaned up footer 
+- Cleaned up footer
 - Cleaned up CSS for front page
 
 ## To do list for future updates

--- a/about.html
+++ b/about.html
@@ -11,8 +11,9 @@
   <meta property="og:description" content="Mightyspaceman About Page">
   <meta property="og:image" content="logo.png">
   <meta name="keywords" content="MightySpaceman, mightyspaceman, about, about me">
-  
+
 <link rel="stylesheet" href="style.css">
+<link id="themeLink" rel="stylesheet" href="dark.css">
 <link rel="icon" type="image/x-icon" href="Images/logo.png">
 
 </head>
@@ -35,13 +36,13 @@
 <h1>About Me</h1>
 <div class="standard">
 <p>
-Hi - I'm a Tasmanian amateur/learning programmer, newbie author, and aerospace enthusiast. I live in Hobart, the capital of Tasmania, which is a really nice place, right on a river...most people 
+Hi - I'm a Tasmanian amateur/learning programmer, newbie author, and aerospace enthusiast. I live in Hobart, the capital of Tasmania, which is a really nice place, right on a river...most people
 say that Tasmania is frigid and cold but, I can tell you, it can get warm (not that the rest of Australia considers 35 degrees particularly 'warm')
 </p>
 <p>
   I recently finished writing a book on the future of space exploration - that took nearly the whole year - and finally released it on the kindle store! I'm currently
-  waiting to see how that'll go in terms of success. Because of this, I am now able to dedicate myself to other projects, and I hope to get better at my programming 
-  skills. Right now I've decided to just learn JavaScript, since it has a lot of useful implementations and frameworks, as well as being a kinda mandatory skill in 
+  waiting to see how that'll go in terms of success. Because of this, I am now able to dedicate myself to other projects, and I hope to get better at my programming
+  skills. Right now I've decided to just learn JavaScript, since it has a lot of useful implementations and frameworks, as well as being a kinda mandatory skill in
   any developer's toolkit. Right as I am writing this I finished adding a light theme button to this website using it :) here, press this <input type="checkbox" id="theme">
 </br></br>if you want to see what I get up to, I guess you could check out my github. Link on the contact page.
 <p>
@@ -60,7 +61,6 @@ say that Tasmania is frigid and cold but, I can tell you, it can get warm (not t
 </div>
 <hr>
 <div class="footer">
-  <p>Dark theme: <input type="checkbox" id="theme"></p>
   <p>
     Contact: <a href="mailto:spaceman384@outlook.com">spaceman384@outlook.com</a>
   </p>

--- a/book.html
+++ b/book.html
@@ -11,8 +11,9 @@
   <meta property="og:description" content="MightySpaceman Book Page">
   <meta property="og:image" content="logo.png">
   <meta name="keywords" content="MightySpaceman, mightyspaceman, book, space, space exploration, touchdown, touchdown - the future of space exploration">
-  
+
 <link rel="stylesheet" href="style.css">
+<link id="themeLink" rel="stylesheet" href="dark.css">
 <link rel="icon" type="image/x-icon" href="Images/logo.png">
 </head>
 <body>
@@ -43,7 +44,6 @@
 </div>
 <hr>
 <div class="footer">
-  <p>Dark theme: <input type="checkbox" id="theme"></p>
   <p>
     Contact: <a href="mailto:spaceman384@outlook.com">spaceman384@outlook.com</a>
   </p>

--- a/contact.html
+++ b/contact.html
@@ -11,8 +11,9 @@
   <meta property="og:description" content="MightySpaceman Contact Page">
   <meta property="og:image" content="logo.png">
   <meta name="keywords" content="MightySpaceman, mightyspaceman, contact, socials, space, space exploration">
-  
+
 <link rel="stylesheet" href="style.css">
+<link id="themeLink" rel="stylesheet" href="dark.css">
 <link rel="icon" type="image/x-icon" href="Images/logo.png">
 </head>
 <body>
@@ -46,7 +47,6 @@
 </div>
 <hr>
 <div class="footer">
-  <p>Dark theme: <input type="checkbox" id="theme"></p>
   <p>
     Contact: <a href="mailto:spaceman384@outlook.com">spaceman384@outlook.com</a>
   </p>

--- a/earthkam.html
+++ b/earthkam.html
@@ -12,8 +12,9 @@
   <meta property="og:description" content="Showcase of my photos from NASA's Sally Ride Earthkam">
   <meta property="og:image" content="logo.png">
   <meta name="keywords" content="MightySpaceman, mightyspaceman, earthkam, ISS, sally ride">
-  
+
 <link rel="stylesheet" href="style.css">
+<link id="themeLink" rel="stylesheet" href="dark.css">
 <link rel="icon" type="image/x-icon" href="Images/logo.png">
 </head>
 <body>
@@ -35,8 +36,8 @@
 <h1>Sally Ride Earthkam Showcase</h1>
 <div class="standard">
 <p>[Image Credit Earthkam.org]</p>
-<p>Recently, I 
-  signed up for the Sally Ride 
+<p>Recently, I
+  signed up for the Sally Ride
   EarthKam program run by NASA.
 When Earthkam runs 4 times a year during mission periods of about a week, students are able to request images of locations on earth along the orbits of the ISS.
 
@@ -109,7 +110,6 @@ you can sign up for Sally Ride EarthKam at <a href="https://earthkam.org/" targe
 <p style="margin: 6vw;">I Do Not (Think) I Own These Images. I was simply involved in the EarthKam program and this page is a showcase of my results.</p>
 <hr>
 <div class="footer">
-  <p>Dark theme: <input type="checkbox" id="theme"></p>
   <p>
     Contact: <a href="mailto:spaceman384@outlook.com">spaceman384@outlook.com</a>
   </p>

--- a/index.html
+++ b/index.html
@@ -54,22 +54,7 @@
 
 <hr>
 
-<div class="footer">
-  <p>
-    Theme:
-    <select id="themeSelect">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </p>
-  <p>
-    Contact: <a href="mailto:spaceman384@outlook.com">spaceman384@outlook.com</a>
-  </p>
-  <p>
-    Mastodon: <a href="https://aus.social/@mightyspaceman">https://aus.social/mightyspaceman</a>
-  </p>
-</div>
+
 
 </div>
 

--- a/projects.html
+++ b/projects.html
@@ -13,8 +13,9 @@
   <meta property="og:description" content="MightySpaceman Projects Page">
   <meta property="og:image" content="logo.png">
   <meta name="keywords" content="MightySpaceman, mightyspaceman, projects, code, space, space exploration">
-  
+
 <link rel="stylesheet" href="style.css">
+<link id="themeLink" rel="stylesheet" href="dark.css">
 <link rel="icon" type="image/x-icon" href="Images/logo.png">
 </head>
 <body>
@@ -48,7 +49,6 @@
 </div>
 <hr>
 <div class="footer">
-  <p>Dark theme: <input type="checkbox" id="theme"></p>
   <p>
     Contact: <a href="mailto:spaceman384@outlook.com">spaceman384@outlook.com</a>
   </p>

--- a/theme.js
+++ b/theme.js
@@ -1,5 +1,43 @@
+/*
+<p>
+    Theme:
+    <select id="themeSelect">
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+    </select>
+</p>
+*/
+
+function createThemeSelectionDialog() {
+    let themeSelectParagraph = document.createElement("p");
+    themeSelectParagraph.innerHTML = "Theme: ";
+    let themeSelect = document.createElement("select");
+    themeSelect.id = "themeSelect";
+    let systemOption = document.createElement("option");
+    systemOption.value = "system";
+    systemOption.innerHTML = "System";
+    themeSelect.appendChild(systemOption);
+    let lightOption = document.createElement("option");
+    lightOption.value = "light";
+    lightOption.innerHTML = "Light";
+    themeSelect.appendChild(lightOption);
+    let darkOption = document.createElement("option");
+    darkOption.value = "dark";
+    darkOption.innerHTML = "Dark";
+    themeSelect.appendChild(darkOption);
+    themeSelectParagraph.appendChild(themeSelect);
+    try {
+        document.getElementsByClassName("footer")[0].prepend(themeSelectParagraph);
+    } catch (error) {
+        console.error("Warning: Could not find footer element to add theme selection dialog to.");
+        console.error(error);
+    }
+    return themeSelect;
+}
+
+const themeSelect = createThemeSelectionDialog();
 const themeLink = document.getElementById("themeLink");
-const themeSelect = document.getElementById("themeSelect");
 
 function setTheme(mode) {
     if (mode === "system") {
@@ -45,3 +83,4 @@ window
     });
 
 updateTheme();
+


### PR DESCRIPTION
I broke the dark/light theme with my last patch. Now every footer class element will have the theme selector so long as the script is called. This is a sub-optimal way to do it and should probably be implemented with a static site build system. Also the style.css and dark.css appear identical. I have added dark.css(/light.css) to every document overriding style.css